### PR TITLE
Add toplevel CMake file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 build_*/*
 .vscode/*
+build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,26 +2,11 @@ cmake_minimum_required(VERSION 3.29)
 
 project(cplusplus-primer)
 
-# See https://github.com/daixtrose/cmake_utilities for what else you can do with FetchContent
-include(FetchContent)
-
-FetchContent_Declare(library_1 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/library_1)
-
-# FetchContent_Declare(example_1 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/example_1)
-FetchContent_Declare(example_2 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/example_2)
-
-# FetchContent_Declare(example_3 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/example_3)
-# FetchContent_Declare(example_4 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/example_4)
-FetchContent_MakeAvailable(library_1)
-
-# FetchContent_MakeAvailable(example_1)
-FetchContent_MakeAvailable(example_2)
-
-# FetchContent_MakeAvailable(example_3)
-# FetchContent_MakeAvailable(example_4)
-
-# add_subdirectory(example_1)
-# add_subdirectory(example_2)
-# add_subdirectory(example_3)
-# add_subdirectory(example_4)
-# add_subdirectory(library_1)
+foreach(subproject example_1 example_2 example_3 example_4 library_1)
+    message(STATUS "Creating '${CMAKE_CURRENT_BINARY_DIR}/build_${subproject}'")
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build_${subproject})
+    add_custom_target(cplusplus-primer-${subproject} ALL
+        COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/build_${subproject} -S ${CMAKE_CURRENT_SOURCE_DIR}/${subproject}
+        COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/build_${subproject}
+    )
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 3.29)
 
 project(cplusplus-primer)
 
+include(ExternalProject)
+
 foreach(subproject example_1 example_2 example_3 example_4 library_1)
-    message(STATUS "Creating '${CMAKE_CURRENT_BINARY_DIR}/build_${subproject}'")
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build_${subproject})
-    add_custom_target(cplusplus-primer-${subproject} ALL
-        COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/build_${subproject} -S ${CMAKE_CURRENT_SOURCE_DIR}/${subproject}
-        COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/build_${subproject}
+    ExternalProject_Add(${subproject}
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${subproject}
+        STEP_TARGETS build
+        INSTALL_COMMAND ""
     )
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.29)
+
+project(cplusplus-primer)
+
+# See https://github.com/daixtrose/cmake_utilities for what else you can do with FetchContent
+include(FetchContent)
+
+FetchContent_Declare(library_1 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/library_1)
+
+# FetchContent_Declare(example_1 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/example_1)
+FetchContent_Declare(example_2 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/example_2)
+
+# FetchContent_Declare(example_3 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/example_3)
+# FetchContent_Declare(example_4 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/example_4)
+FetchContent_MakeAvailable(library_1)
+
+# FetchContent_MakeAvailable(example_1)
+FetchContent_MakeAvailable(example_2)
+
+# FetchContent_MakeAvailable(example_3)
+# FetchContent_MakeAvailable(example_4)
+
+# add_subdirectory(example_1)
+# add_subdirectory(example_2)
+# add_subdirectory(example_3)
+# add_subdirectory(example_4)
+# add_subdirectory(library_1)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A short introduction to C++. The examples build on top of each other. A special 
   - Use for testing small C++ code snippets
 - [Craig Scott: "Professional CMake"](https://crascit.com/professional-cmake/)    
   - The one and only book you need about build systems 
+- [HSF - More Modern CMake](https://hsf-training.github.io/hsf-training-cmake-webpage/index.html)
 
 ## List of Subprojects
 

--- a/example_2/CMakeLists.txt
+++ b/example_2/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(example_2
 # add_subdirectory(../library_1 ../build_library_1)
 # but be aware of parallel builds!
 # In general, keep builds separate. KISS principle!
-add_subdirectory(../library_1 build_library_1)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../library_1 build_library_1)
 
 target_link_libraries(
     ${PROJECT_NAME}

--- a/example_3/CMakeLists.txt
+++ b/example_3/CMakeLists.txt
@@ -18,7 +18,12 @@ include(FetchContent)
 # since the code for every dependency is stored on disk exactly once.
 FetchContent_Declare(
     library_1
-    SOURCE_DIR ../library_1
+
+    # Quote from Craig Scott, "Professional CMake":
+    # CMAKE_CURRENT_SOURCE_DIR is the directory of the CMakeLists.txt file currently being
+    # processed by CMake. It is updated each time a new file is processed as a result of an
+    # add_subdirectory() call and is restored back again when processing of that directory is complete.
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../library_1
 )
 
 FetchContent_MakeAvailable(library_1)

--- a/example_4/CMakeLists.txt
+++ b/example_4/CMakeLists.txt
@@ -18,7 +18,7 @@ include(FetchContent)
 # since the code for every dependency is stored on disk exactly once.
 FetchContent_Declare(
     library_1
-    SOURCE_DIR ../library_1
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../library_1
 )
 
 FetchContent_MakeAvailable(library_1)

--- a/example_4/README.md
+++ b/example_4/README.md
@@ -123,7 +123,7 @@ Here we illustrate recommended ways to use `cmake` in a **portable way**. See [t
 Create a subdirectory `build_example_4` and prepare the build system for the source in `example_4` in this subdirectory:
 
 ```bash
-cmake -D CMAKE_BUILD_TYPE=Release -B build_example_4 -S example_4
+cmake -D CMAKE_BUILD_TYPE=Release -B build_example_4 -S example_4 --fresh
 # for debug builds use   
 # cmake -D CMAKE_BUILD_TYPE=Debug -B build_example_4 -S example_4
 ```
@@ -133,7 +133,7 @@ cmake -D CMAKE_BUILD_TYPE=Release -B build_example_4 -S example_4
 Call `cmake` from the top level like this:
 
 ```bash
-cmake --build build_example_4 --config Release --target example_4
+cmake --build build_example_4 --config Release --target example_4 --clean-first
 ```
 
 ### Creating release packages


### PR DESCRIPTION
## Add a top-level CMake file to build them all

This approach still has issues, especially because it does not configure the clean target, which is quite annoying.